### PR TITLE
`@uviews` macro hygiene issue

### DIFF
--- a/src/uview.jl
+++ b/src/uview.jl
@@ -131,7 +131,7 @@ macro uviews(args...)
     binds = Expr(:block)
     for s in syms
         s isa Symbol || error("@uviews targets must be a symbols")
-        push!(binds.args, :($s = $uview($s)))
+        push!(binds.args, :($s = $UnsafeArrays.uview($s)))
     end
     let_expr = Expr(:let, binds, expr)
     esc(:(GC.@preserve $(syms...) $(let_expr)))

--- a/src/uview.jl
+++ b/src/uview.jl
@@ -131,7 +131,7 @@ macro uviews(args...)
     binds = Expr(:block)
     for s in syms
         s isa Symbol || error("@uviews targets must be a symbols")
-        push!(binds.args, :($s = UnsafeArrays.uview($s)))
+        push!(binds.args, :($s = $uview($s)))
     end
     let_expr = Expr(:let, binds, expr)
     esc(:(GC.@preserve $(syms...) $(let_expr)))

--- a/test/uview.jl
+++ b/test/uview.jl
@@ -91,19 +91,27 @@ using Random
         A = rand(Int32, 8)
         B = rand(ComplexF64, 3, 5, 4)
 
-        uviews(() -> 42) == 42
-        uviews(A -> typeof(A), A) == UnsafeArray{Int32, 1}
-        uviews((A, B) -> (typeof(A), typeof(B)), A, B) == UnsafeArray{Int32, 1}
+        @test uviews(() -> 42) == 42
+        @test uviews(A -> typeof(A), A) == UnsafeArray{Int32, 1}
+        @test uviews((A, B) -> (typeof(A), typeof(B)), A, B) == (UnsafeArray{Int32, 1}, UnsafeArray{ComplexF64, 3})
     end
 
 
     @testset "@uviews" begin
+        @eval module TestMacroScope
+
+        # Test `@uviews` macro in a new module with minimal symbols imported from `UnsafeArrays`
+        using UnsafeArrays: UnsafeArray, @uviews
+        using Test
+
         A = rand(Int32, 8)
         B = rand(ComplexF64, 3, 5, 4)
 
-        @uviews(42) == 42
-        @uviews(A, typeof(A)) == UnsafeArray{Int32, 1}
-        @uviews(A, B, (typeof(A), typeof(B))) == UnsafeArray{Int32, 1}
+        @test @uviews(42) == 42
+        @test @uviews(A, typeof(A)) == UnsafeArray{Int32, 1}
+        @test @uviews(A, B, (typeof(A), typeof(B))) == (UnsafeArray{Int32, 1}, UnsafeArray{ComplexF64, 3})
+
+        end # module TestMacroScope
     end
 
 


### PR DESCRIPTION
The `@uviews` macro fails if the `UnsafeArrays` module symbol is not available in the current scope. MWE:

```julia
using UnsafeArrays: @uviews
A = rand(3, 3)
@uviews A view(A, 1, :) # UndefVarError: `UnsafeArrays` not defined
```

The issue is that when the macro builds the expression, it refers to `UnsafeArrays.uview`.

I fixed it by just interpolating `$UnsafeArrays.uview` instead, and modified the tests to run inside a dummy module where `UnsafeArrays` is not defined. I also fixed a couple silently broken tests that were not being run.