### PR TITLE
Fix IndexStyle

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "UnsafeArrays"
 uuid = "c4a57d5a-5b31-53a6-b365-19f8c011fbd6"
-version = "1.0.6"
+version = "1.0.7"
 
 [compat]
 julia = "1"

--- a/src/unsafe_array.jl
+++ b/src/unsafe_array.jl
@@ -60,7 +60,8 @@ end
     unsafe_store!(A.pointer, x, i)
 end
 
-@inline Base.IndexStyle(A::UnsafeArray) = IndexLinear()
+@inline Base.IndexStyle(A::UnsafeArray) = Base.IndexStyle(typeof(A))
+Base.IndexStyle(::Type{UnsafeArray{T,N}}) where {T,N} = IndexLinear()
 
 Base.unsafe_convert(::Type{Ptr{T}}, A::UnsafeArray{T}) where T = A.pointer
 

--- a/test/unsafe_array.jl
+++ b/test/unsafe_array.jl
@@ -67,6 +67,7 @@ using Random
             T = eltype(UA)
             @test @inferred(length(UA)) == length(A)
             @test @inferred(IndexStyle(UA)) == IndexLinear()
+            @test @inferred(IndexStyle(typeof(UA))) == IndexLinear()
             @test @inferred(LinearIndices(UA)) == LinearIndices(A)
             @test @inferred(eachindex(UA)) == eachindex(A)
 


### PR DESCRIPTION
This PR fixes the definition of `IndexStyle` which must dispatch on the array type, not the array value.
We keep the convenience function which uses the array value.

Before this PR, in practice, unsafe arrays used `IndexCartesian` instead of `IndexLinear` because that is the default (there was no method defined on the type of an unsafe array). This prevented certain optimizations.
